### PR TITLE
Update add card page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ This is the Angular2 based front end of the CardIndexer project. This is a proje
 
 I want to be able to both index what I have for myself, and be able to give my friends an easy way to browse my cards for anything they would like to trade/buy from me.
 
+## Components overview
+In this project are the following components:
+* The add card page
+* The card collection page
+
+The following are still going to be added:
+* Create/update decks page
+* Decks overview page
+* Deck information page
+
+### The add card page
+The add card page consists of three components:
+1. The `add-card-page` component
+2. The `select-card-versions` component
+3. The `card-selector` component
+
+The `add-card-page` component creates multiple `select-card-versions` components. 
+These are used to search and select the cards to be added.
+
+Each result found on the mtg.io API is displayed as a `card-selector` component. These are the children of the `select-card-versions` component.
+Each of these displays the card image, its name and extra finishes of these cards (i.e. oil slick or serialization).
+
+### The card collection page
+The card collection page displays all cards I have in my collection.
+This is a work in progress
+
 
 # Angular2
 

--- a/src/app/add-card/card-selector/components/card-selector.component.ts
+++ b/src/app/add-card/card-selector/components/card-selector.component.ts
@@ -13,6 +13,7 @@ export class CardSelectorComponent {
   
   image_url : string = "";
   promotypes? : string[];
+  finishes? : string[];
 
   ngOnInit() {
     // Call the scryfall API for information
@@ -22,10 +23,12 @@ export class CardSelectorComponent {
   getInformation() {
     this.scryfallAPIService.getCardInformation(this.card.versions[0].set_code, this.card.versions[0].number).subscribe( res => {
       if(res.image_uris !== undefined)
-        this.image_url = res.image_uris["large"];
+        this.image_url = res.image_uris["normal"];
 
         if(res.promo_types !== undefined)
           this.promotypes = res.promo_types
+        if(res.finishes !== undefined)
+          this.finishes = res.finishes
     })
   }
 

--- a/src/app/add-card/card-selector/components/card-selector.component.ts
+++ b/src/app/add-card/card-selector/components/card-selector.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Card, CardVersion } from '../../../shared/models/card';
 import { ScryfallAPIService } from '../../../shared/scryfallAPI/scyfall-api.service';
 
@@ -9,28 +9,55 @@ import { ScryfallAPIService } from '../../../shared/scryfallAPI/scyfall-api.serv
   styleUrls: ['../pages/card-selector.component.scss']
 })
 export class CardSelectorComponent {
-  constructor(private scryfallAPIService : ScryfallAPIService) {}
+  constructor(
+    private scryfallAPIService : ScryfallAPIService,
+    private fb: FormBuilder) {}
   
   image_url : string = "";
   promotypes? : string[];
   finishes? : string[];
 
+  tc = this.fb.array([]);
+
+  finishCounterForm = this.fb.group({
+    cardCounts: this.tc
+  });
+
+  // This function is used to dynamically generate the form controls; 
+  // we need one FromControl per type of finish. SOmetimes this is one, two, or more
+  setupFormControl() {    
+    if(this.finishes === undefined)
+      return;
+    
+      // Per finish we create one numeric input
+    for (let i = 0; i < this.finishes.length; i++)      
+      this.tc.push(this.fb.control(0));
+  }
+
   ngOnInit() {
     // Call the scryfall API for information
     this.getInformation();
+    
   }
 
   getInformation() {
     this.scryfallAPIService.getCardInformation(this.card.versions[0].set_code, this.card.versions[0].number).subscribe( res => {
       if(res.image_uris !== undefined)
         this.image_url = res.image_uris["normal"];
+        
 
         if(res.promo_types !== undefined)
-          this.promotypes = res.promo_types
+          this.promotypes = res.promo_types;
+          
+        
         if(res.finishes !== undefined)
-          this.finishes = res.finishes
+          this.finishes = res.finishes;
+
+        // Since we require the information from the scryfallAPI we call the setup form control here
+        this.setupFormControl();
     })
   }
+
 
 
   cardCounterForm = new FormGroup({

--- a/src/app/add-card/card-selector/components/card-selector.component.ts
+++ b/src/app/add-card/card-selector/components/card-selector.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Card, CardVersion } from '../../../shared/models/card';
-import { ScryfallAPIService } from '../../../shared/scryfallAPI/scyfall-api.service';
+import { ScryfallAPIService, ScryfallCardAPIModel } from '../../../shared/scryfallAPI/scyfall-api.service';
 
 @Component({
   selector: 'app-card-selector',
@@ -12,52 +12,85 @@ export class CardSelectorComponent {
   constructor(
     private scryfallAPIService : ScryfallAPIService,
     private fb: FormBuilder) {}
+
+  // Input field to determine what card we are displaying. All other information is derived from this
+  @Input() public card! : Card;
   
+  // ScyrfallAPI data
   image_url : string = "";
   promotypes? : string[];
   finishes? : string[];
-
+  
+  // Form control fields
   tc = this.fb.array([]);
 
   finishCounterForm = this.fb.group({
     cardCounts: this.tc
   });
 
-  // This function is used to dynamically generate the form controls; 
-  // we need one FromControl per type of finish. SOmetimes this is one, two, or more
-  setupFormControl() {    
-    if(this.finishes === undefined)
-      return;
-    
-      // Per finish we create one numeric input
-    for (let i = 0; i < this.finishes.length; i++)      
-      this.tc.push(this.fb.control(0));
-  }
-
   ngOnInit() {
     // Call the scryfall API for information
     this.getInformation();
-    
   }
 
+  // Set the values retrieved from the scryfall API locally
+  // Then we calculate all fields that are derived from them (i.e. the form control)
   getInformation() {
     this.scryfallAPIService.getCardInformation(this.card.versions[0].set_code, this.card.versions[0].number).subscribe( res => {
-      if(res.image_uris !== undefined)
-        this.image_url = res.image_uris["normal"];
-        
-
-        if(res.promo_types !== undefined)
-          this.promotypes = res.promo_types;
-          
-        
-        if(res.finishes !== undefined)
-          this.finishes = res.finishes;
-
-        // Since we require the information from the scryfallAPI we call the setup form control here
+        this.setInformation(res);
         this.setupFormControl();
     })
   }
 
+  // Set and clean the values retrieved from the ScryfallAPI
+  setInformation(res : ScryfallCardAPIModel) {
+    if(res.image_uris !== undefined)
+      this.image_url = res.image_uris["normal"];
+
+    if(res.promo_types !== undefined)
+      this.promotypes = res.promo_types;
+    
+    if(res.finishes !== undefined) {
+      this.finishes = res.finishes;
+      
+      // I prefer to read non foil over nonfoil (adding a space in between)
+      for (let i = 0; i < this.finishes.length; i++)
+        if(this.finishes[i] == "nonfoil")
+          this.finishes[i] = "non foil";
+    }
+  }
+
+  // This function is used to dynamically generate the form controls; 
+  // we need one FromControl per type of finish. Sometimes this is one, two, or more
+  setupFormControl() {    
+    if(this.finishes === undefined)
+      return;
+    
+    // Per finish we create one numeric input
+    for (let i = 0; i < this.finishes.length; i++)      
+      this.tc.push(this.fb.control(0));
+  }
+
+  // Generates and sets a card version from the finish name and the number put in
+  // Here we can use the card.versions[0] for the values of the multiverseID etc,
+  // because input is a single card with a version. We use that CardVersion for the scryfall API aswell
+  private generateVersion(finish : string, count : number) : CardVersion {
+
+    // TEMPORARY: Remove this with the updated card model
+    var foilstatus = false;
+    if(finish != "nonfoil")
+      foilstatus = true;
+
+
+    return {
+      "card_count" : count,
+      "multiverseID" : this.card.versions[0].multiverseID,
+      "set_code" : this.card.versions[0].set_code,
+      "number" : this.card.versions[0].number,
+      "foil" : foilstatus,
+      // "finish" : finish
+    } 
+  }
 
 
   cardCounterForm = new FormGroup({
@@ -65,51 +98,29 @@ export class CardSelectorComponent {
     foilCountControl: new FormControl(0)
   });
 
-  @Input() public card! : Card;
   public totalSelected = 0;
 
-  getUrl() {
-    this.image_url=`https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`;
-
-    console.log(`https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`)
-    return `https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`
-  }
-
+     
   public readData() {
-    // First we determine whether or not we have any cards selected.
-    var regularCount = this.cardCounterForm.value.countControl;
-    var foilCount = this.cardCounterForm.value.foilCountControl;
-
     var versions : CardVersion[] = [];
 
-    // If we do have cards selected we generate the card object.
-    if (regularCount && regularCount > 0) {
-      var regularVersion = {
-        "card_count" : regularCount,
-        "multiverseID" : this.card.versions[0].multiverseID,
-        "set_code" : this.card.versions[0].set_code,
-        "foil" : false,
-        "number" : this.card.versions[0].number
-      } as CardVersion;
+    if (this.finishes === undefined)
+      return;
 
-      versions.push(regularVersion);
-      this.totalSelected += regularCount;
+    for (let i = 0; i < this.finishes.length; i++) {
+      // Dirty typecast to prevent errors
+      var count = this.tc.at(i).value as number;
+
+      if (count === 0)
+        continue;
+
+      // DEBUG
+      console.log(`Added cards: ${this.card.versions[0].set_code}, ${this.finishes[i]} ${count}`);
+      
+      this.totalSelected += count;
+      versions.push(this.generateVersion(this.finishes[i], count));
     }
 
-      // Now we generate the foil cards version object
-      if (foilCount && foilCount > 0) {
-        var foilVersion = {
-          "card_count" : foilCount,
-          "multiverseID" : this.card.versions[0].multiverseID,
-          "set_code" : this.card.versions[0].set_code,
-          "number" : this.card.versions[0].number,
-          "foil" : true
-        } as CardVersion;
-        
-        versions.push(foilVersion);
-        this.totalSelected += foilCount;
-      }
-
-      this.card.versions = versions;
+    this.card.versions = versions;
   }
 }

--- a/src/app/add-card/card-selector/components/card-selector.component.ts
+++ b/src/app/add-card/card-selector/components/card-selector.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Card, CardVersion } from '../../../shared/models/card';
+import { ScryfallAPIService } from '../../../shared/scryfallAPI/scyfall-api.service';
 
 @Component({
   selector: 'app-card-selector',
@@ -8,15 +9,25 @@ import { Card, CardVersion } from '../../../shared/models/card';
   styleUrls: ['../pages/card-selector.component.scss']
 })
 export class CardSelectorComponent {
-  constructor() {}
+  constructor(private scryfallAPIService : ScryfallAPIService) {}
   
+  image_url : string = "";
+  promotypes? : string[];
+
   ngOnInit() {
     // Call the scryfall API for information
-    this.getUrl();
+    this.getInformation();
   }
 
-  url = "";
+  getInformation() {
+    this.scryfallAPIService.getCardInformation(this.card.versions[0].set_code, this.card.versions[0].number).subscribe( res => {
+      if(res.image_uris !== undefined)
+        this.image_url = res.image_uris["large"];
 
+        if(res.promo_types !== undefined)
+          this.promotypes = res.promo_types
+    })
+  }
 
 
   cardCounterForm = new FormGroup({
@@ -28,7 +39,7 @@ export class CardSelectorComponent {
   public totalSelected = 0;
 
   getUrl() {
-    this.url=`https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`;
+    this.image_url=`https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`;
 
     console.log(`https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`)
     return `https://api.scryfall.com/cards/${this.card.versions[0].set_code}/${this.card.versions[0].number}?format=image`

--- a/src/app/add-card/card-selector/pages/card-selector.component.html
+++ b/src/app/add-card/card-selector/pages/card-selector.component.html
@@ -6,9 +6,20 @@
         <label for="foil-count">Foil:</label>
         <input id="foil-count" type ="number" min="0" formControlName="foilCountControl">
     </form>
+
+    <!-- <form style="margin:20px;">
+        <span *ngFor="let finish of finishes">
+            <label>{{finish}}</label>
+            <input id="regular-count" type ="number" min="0">
+        </span>
+    </form> -->
     
-    <div class="imgcontainer">
-        <img class="carddisplay" src="{{image_url}}"/>
+    <div class="imgcontainer"
+        [ngStyle]="{ 'background-image': 'url(' + image_url + ')'}">
+        <!-- <img class="carddisplay" src="{{image_url}}"/> -->
+        <div *ngFor="let promotype of promotypes" class="promotypes-container">
+            <span>{{promotype}}</span>
+        </div>
     </div>
 
     <!-- https://api.scryfall.com/cards/{{card.versions[0].set_code}}/{{card.versions[0].number}}?format=image -->

--- a/src/app/add-card/card-selector/pages/card-selector.component.html
+++ b/src/app/add-card/card-selector/pages/card-selector.component.html
@@ -1,24 +1,61 @@
 <div class="selector-container">
-    <form class="count-form" [formGroup]="cardCounterForm" (ngSubmit)="readData()">   
+    <!-- <form class="count-form" [formGroup]="cardCounterForm" (ngSubmit)="readData()">   
         <label for="regular-count">Regular:</label>
         <input id="regular-count" type ="number" min="0" formControlName="countControl">
         
         <label for="foil-count">Foil:</label>
         <input id="foil-count" type ="number" min="0" formControlName="foilCountControl">
-    </form>
+    </form> -->
 
     <!-- <form style="margin:20px;">
+        <div *ngFor="let control of finishCounterForm.controls; index as i">
+            <input type ="number" min="0" [formControl]="finishCounterForm.controls[i]">
+        </div>
         <span *ngFor="let finish of finishes">
-            <label>{{finish}}</label>
+            <label>{{finish | titlecase}}</label>
+            <input type ="number" min="0" [formControl]="finishCounterForm[finish]">
             <input id="regular-count" type ="number" min="0">
         </span>
     </form> -->
+    <!-- <div formArrayName="finishControls">
+        <span *ngFor="let finish of finishControls['controls']; let i=index">
+            <input type ="number" min="0" [formControlName]="i">
+        </span>
+    </div> -->
+
+
+
+    <div [formGroup]="finishCounterForm">
+        <div formArrayName="cardCounts">
+            <span *ngFor="let finish of finishes; let i=index">
+                <label>{{finish | titlecase}}</label>
+                <input type ="number" min="0" [formControlName]="i">
+                <!-- <input id="regular-count" type ="number" min="0"> -->
+            </span>
+        </div>
+    </div>
     
+
+
+
+
+
+
+    <!--
+    THIS ONE WORKS WITHOUT LABELS
+         
+    <div [formGroup]="finishCounterForm">
+        <div formArrayName="cardCounts">
+            <span *ngFor="let finish of tc.controls; let i=index">
+                <input type ="number" min="0" [formControlName]="i">
+            </span>
+        </div>
+    </div> -->
     <div class="imgcontainer"
         [ngStyle]="{ 'background-image': 'url(' + image_url + ')'}">
         <!-- <img class="carddisplay" src="{{image_url}}"/> -->
         <div *ngFor="let promotype of promotypes" class="promotypes-container">
-            <span>{{promotype}}</span>
+            <span>{{promotype | titlecase}}</span>
         </div>
     </div>
 

--- a/src/app/add-card/card-selector/pages/card-selector.component.html
+++ b/src/app/add-card/card-selector/pages/card-selector.component.html
@@ -1,56 +1,14 @@
 <div class="selector-container">
-    <!-- <form class="count-form" [formGroup]="cardCounterForm" (ngSubmit)="readData()">   
-        <label for="regular-count">Regular:</label>
-        <input id="regular-count" type ="number" min="0" formControlName="countControl">
-        
-        <label for="foil-count">Foil:</label>
-        <input id="foil-count" type ="number" min="0" formControlName="foilCountControl">
-    </form> -->
 
-    <!-- <form style="margin:20px;">
-        <div *ngFor="let control of finishCounterForm.controls; index as i">
-            <input type ="number" min="0" [formControl]="finishCounterForm.controls[i]">
-        </div>
-        <span *ngFor="let finish of finishes">
-            <label>{{finish | titlecase}}</label>
-            <input type ="number" min="0" [formControl]="finishCounterForm[finish]">
-            <input id="regular-count" type ="number" min="0">
-        </span>
-    </form> -->
-    <!-- <div formArrayName="finishControls">
-        <span *ngFor="let finish of finishControls['controls']; let i=index">
-            <input type ="number" min="0" [formControlName]="i">
-        </span>
-    </div> -->
-
-
-
-    <div [formGroup]="finishCounterForm">
+    <form class="count-form" [formGroup]="finishCounterForm" (ngSubmit)="readData()">   
         <div formArrayName="cardCounts">
             <span *ngFor="let finish of finishes; let i=index">
                 <label>{{finish | titlecase}}</label>
                 <input type ="number" min="0" [formControlName]="i">
-                <!-- <input id="regular-count" type ="number" min="0"> -->
             </span>
         </div>
-    </div>
+    </form>
     
-
-
-
-
-
-
-    <!--
-    THIS ONE WORKS WITHOUT LABELS
-         
-    <div [formGroup]="finishCounterForm">
-        <div formArrayName="cardCounts">
-            <span *ngFor="let finish of tc.controls; let i=index">
-                <input type ="number" min="0" [formControlName]="i">
-            </span>
-        </div>
-    </div> -->
     <div class="imgcontainer"
         [ngStyle]="{ 'background-image': 'url(' + image_url + ')'}">
         <!-- <img class="carddisplay" src="{{image_url}}"/> -->

--- a/src/app/add-card/card-selector/pages/card-selector.component.html
+++ b/src/app/add-card/card-selector/pages/card-selector.component.html
@@ -17,6 +17,4 @@
         </div>
     </div>
 
-    <!-- https://api.scryfall.com/cards/{{card.versions[0].set_code}}/{{card.versions[0].number}}?format=image -->
-
 </div>

--- a/src/app/add-card/card-selector/pages/card-selector.component.html
+++ b/src/app/add-card/card-selector/pages/card-selector.component.html
@@ -1,4 +1,3 @@
-
 <div class="selector-container">
     <form class="count-form" [formGroup]="cardCounterForm" (ngSubmit)="readData()">   
         <label for="regular-count">Regular:</label>
@@ -9,10 +8,9 @@
     </form>
     
     <div class="imgcontainer">
-        <img class="carddisplay" src="{{url}}"/>
+        <img class="carddisplay" src="{{image_url}}"/>
     </div>
 
     <!-- https://api.scryfall.com/cards/{{card.versions[0].set_code}}/{{card.versions[0].number}}?format=image -->
-
 
 </div>

--- a/src/app/add-card/card-selector/pages/card-selector.component.scss
+++ b/src/app/add-card/card-selector/pages/card-selector.component.scss
@@ -9,10 +9,7 @@
     border-color: darkgrey;
 }
 
-.carddisplay {
-    width: 265px;
-    height: 370px;
-}
+
 
 input {
     width: 50px;
@@ -20,5 +17,33 @@ input {
 
 .count-form {
     margin: auto;
-    width: 75%;
+    width: 90%;
+}
+
+$cardheight: 370px;
+
+.imgcontainer {
+    width: 265px;
+    height: $cardheight;
+    
+    background-size:contain;
+    
+    .promotypes-container {
+        background-color: rgba(100,0,0, 1);
+        border-radius: 3px;
+
+        color: white;
+        position: relative;
+
+        padding-left: 5px;
+        padding-right: 5px;
+
+        display: table;
+        margin: 0 auto;
+        margin-top: 1px;
+        top: $cardheight - 100px;
+
+    }
+
+
 }

--- a/src/app/add-card/card-selector/pages/card-selector.component.scss
+++ b/src/app/add-card/card-selector/pages/card-selector.component.scss
@@ -1,4 +1,4 @@
-
+$cardheight: 370px;
 
 .selector-container {
     display: inline-block;
@@ -9,18 +9,26 @@
     border-color: darkgrey;
 }
 
-
-
-input {
-    width: 50px;
-}
-
 .count-form {
     margin: auto;
     width: 90%;
+    position: relative;
+
+    label {
+        margin-right: 2px;
+        margin-left: 7px;
+    }
+
+    input {
+        width: 50px;
+    }
+
+
 }
 
-$cardheight: 370px;
+
+
+
 
 .imgcontainer {
     width: 265px;

--- a/src/app/add-card/card-selector/pages/card-selector.component.scss
+++ b/src/app/add-card/card-selector/pages/card-selector.component.scss
@@ -30,13 +30,16 @@ $cardheight: 370px;
     
     .promotypes-container {
         background-color: rgba(100,0,0, 1);
-        border-radius: 3px;
+
+        border-color: rgb(200, 200, 200);
+        border-width: 2px;
+        border-style: solid;
+        border-radius: 5px;
 
         color: white;
         position: relative;
 
-        padding-left: 5px;
-        padding-right: 5px;
+        padding: 3px 5px;
 
         display: table;
         margin: 0 auto;

--- a/src/app/card-collection-overview/card-collection-overview/components/card-collection-overview.component.ts
+++ b/src/app/card-collection-overview/card-collection-overview/components/card-collection-overview.component.ts
@@ -22,6 +22,7 @@ export class CardCollectionOverviewComponent {
     this.collecteDBService.getAllCards().subscribe(fetched => this.cards = fetched);
   }
 
+  // For displaying how many cards are in the collection in total
   countCards(card: Card) : number {
     var cnt = 0;
     for (var version of card.versions)

--- a/src/app/shared/scryfallAPI/scyfall-api.service.spec.ts
+++ b/src/app/shared/scryfallAPI/scyfall-api.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ScyfallAPIService } from './scyfall-api.service';
+import { ScryfallAPIService } from './scyfall-api.service';
 
 describe('ScyfallAPIService', () => {
-  let service: ScyfallAPIService;
+  let service: ScryfallAPIService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(ScyfallAPIService);
+    service = TestBed.inject(ScryfallAPIService);
   });
 
   it('should be created', () => {

--- a/src/app/shared/scryfallAPI/scyfall-api.service.ts
+++ b/src/app/shared/scryfallAPI/scyfall-api.service.ts
@@ -1,11 +1,68 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Observable, catchError, map, of, tap } from 'rxjs';
+
+import { MessageService } from '../messages/services/messages.service';
+
 
 @Injectable({
   providedIn: 'root'
 })
-export class ScyfallAPIService {
+export class ScryfallAPIService {
 
-  constructor() { }
+  constructor(
+    private http: HttpClient,
+    private messageService: MessageService) { }
+
+  private log(message: string) {
+    this.messageService.add(`Scryfall API Service: ${message}`);
+  }
+
+  // TODO
+  // URL for the API, this needs to be configurable from a config file in the future
+  // This URL is specifically for the cards component of the Scryfall API.
+  // When we use more of this API (sets, and collection synchronization) we need to change this URL.
+  private apiURL = "https://api.scryfall.com/cards/"
+
+  httpOptions = {
+    headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+  };
+
+  // Just get all the information we need from the Scryfall API.
+  // This incldues the iamge and the promotypes array.
+  // Later we can send this information to a buffer or to the collecteDB API
+  getCardInformation(set_code? : string, number? : string) : Observable<ScryfallCardAPIModel> {
+    this.log(`Seached for ${set_code}/${number}`);
+
+    return this.http.get<ScryfallCardAPIModel>(`${this.apiURL}${set_code}/${number}`)
+    .pipe(
+      catchError(this.handleError<ScryfallCardAPIModel>('getCardInfo')),
+      map(res => this.reportScryfallErrorcodes(res))
+    );  
+  }
+
+  // We don't have to do extensive error checking for empty return values as we have to check if the fields are present later anyway 
+  private reportScryfallErrorcodes(apiResponse : ScryfallCardAPIModel) : ScryfallCardAPIModel {
+    if(apiResponse.object == "error")
+      this.log(`Failed to get cards: ${apiResponse.code}, ${apiResponse.details}`);
+    
+    return apiResponse;
+  }
+
+  private handleError<T>(operation = 'default operation', result?: T){
+    return (error: any): Observable<T> => {
+
+      // TODO: send the error to remote logging infrastructure
+      console.error(error); // log to console instead
+  
+      // TODO: better job of transforming error for user consumption
+      this.log(`${operation} failed: ${error.message}`);
+  
+      // Let the app keep running by returning an empty result.
+      return of(result as T);
+    };
+  }
+
 }
 
 

--- a/src/app/shared/scryfallAPI/scyfall-api.service.ts
+++ b/src/app/shared/scryfallAPI/scyfall-api.service.ts
@@ -32,7 +32,7 @@ export class ScryfallAPIService {
   // This incldues the iamge and the promotypes array.
   // Later we can send this information to a buffer or to the collecteDB API
   getCardInformation(set_code? : string, number? : string) : Observable<ScryfallCardAPIModel> {
-    // this.log(`Seached for ${set_code}/${number}`);
+    this.log(`Seached for ${set_code}/${number}`);
 
     return this.http.get<ScryfallCardAPIModel>(`${this.apiURL}${set_code}/${number}`)
     .pipe(
@@ -66,7 +66,7 @@ export class ScryfallAPIService {
 }
 
 
-interface ScryfallCardAPIModel {
+export interface ScryfallCardAPIModel {
   object : string;
 
   // Error response:

--- a/src/app/shared/scryfallAPI/scyfall-api.service.ts
+++ b/src/app/shared/scryfallAPI/scyfall-api.service.ts
@@ -32,7 +32,7 @@ export class ScryfallAPIService {
   // This incldues the iamge and the promotypes array.
   // Later we can send this information to a buffer or to the collecteDB API
   getCardInformation(set_code? : string, number? : string) : Observable<ScryfallCardAPIModel> {
-    this.log(`Seached for ${set_code}/${number}`);
+    // this.log(`Seached for ${set_code}/${number}`);
 
     return this.http.get<ScryfallCardAPIModel>(`${this.apiURL}${set_code}/${number}`)
     .pipe(
@@ -80,4 +80,5 @@ interface ScryfallCardAPIModel {
   cardmarket_id? : number;
   image_uris? : { [key:string] : string };
   promo_types? : string[];
+  finishes? : string[]
 }


### PR DESCRIPTION
Implemented issue #5 . Also added support for flexible card finishes on the add card page: you can now only add foil versions of cards that have foil versions. Same goes for non-foil cards. Also supports special finishes like etched (see, _Ragavan, Nimble Pilferer_ from Multiverse Legends, with collector's number 86).

In the code there is support for issue #13 as well, but the card model needs to be updated again. See issue #13 for that.